### PR TITLE
Bug fix in redis consumer with respect to parsing list of events.  

### DIFF
--- a/tests/api/RedisConsumer.test.js
+++ b/tests/api/RedisConsumer.test.js
@@ -34,11 +34,11 @@ describe('RedisConsumer', () => {
 
       expect(callback.calledWith(
         null,
-        {
+        [{
           topic: 'sedaily-event-stream1',
           eventId: ['123244'],
           eventData: ['data'],
-        }
+        }]
       )).to.equal(true);
     });
 
@@ -67,11 +67,11 @@ describe('RedisConsumer', () => {
 
       expect(callback.calledWith(
         null,
-        {
+        [{
           topic: 'sedaily-event-stream1',
           eventId: ['123244'],
           eventData: ['data'],
-        }
+        }]
       )).to.equal(true);
     });
 


### PR DESCRIPTION
- Always return a list of events to the client callback  function passed to the getSlice or subscribe method  of the EventStream consume
- Add basic schema validation for the args passed to the subscribe method of the EventStrema consumer