### PR TITLE
Use API param validation for Influx event schema

### DIFF
--- a/server/helpers/InfluxEventInterface.js
+++ b/server/helpers/InfluxEventInterface.js
@@ -1,5 +1,24 @@
+import _ from 'lodash';
 import { FieldType, escape } from 'influx';
 import InfluxInterface from './InfluxInterface';
+import paramValidation from '../../config/param-validation';
+
+const fieldList = Object.keys(paramValidation.event.body);
+fieldList.splice(fieldList.indexOf('eventData'), 1);
+
+Object.keys(paramValidation).forEach((key) => {
+  const inner = paramValidation[key]._inner;
+  if (inner && inner.children) {
+    inner.children.forEach((child) => {
+      fieldList.push(child.key);
+    });
+  }
+});
+
+const fields = {};
+Array.from(new Set(fieldList)).forEach((field) => {
+  fields[field] = FieldType.STRING;
+});
 
 const databaseName = 'eventsDb';
 
@@ -8,21 +27,18 @@ export default class InfluxEventInterface extends InfluxInterface {
     super(databaseName, [
       {
         measurement: 'events',
-        fields: {
-          eventData: FieldType.STRING
-        },
-        tags: [
-          'eventType'
-        ]
+        fields,
+        tags: []
       }
     ]);
   }
 
   write(topic, eventData, callback) {
+    _.merge(eventData, eventData.eventData);
+    delete eventData.eventData; // eslint-disable-line no-param-reassign
     this.influx.writeMeasurement('events', [
       {
-        tags: { eventType: eventData.eventType },
-        fields: { eventData: JSON.stringify(eventData) }
+        fields: { ...eventData }
       }
     ])
       .then(() => {


### PR DESCRIPTION
Instead of storing all of the event data into one column in Influx as a stringified JSON value, each field in the event becomes its own column. This allows us to have much better reporting. One downside is that some values in a row will be empty. For example, a `pauseEpisode` event has the "minutesPlayed" field, but a `register` event does not. 

I couldn't tag @dfcook as a reviewer but wanted your input on it as well.